### PR TITLE
Contributing guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,15 +21,14 @@ to accept contributions on various aspects of our repositories, including:
 Feedback & Requests
 -------------------
 
-For any feedback, or requests, on the code, documentation or anything else, please create a GitHub
-issue to describe your suggestion and open the discussion. We have created some issue templates to
-show the information we expect for different types of suggestions.
+If you have any feedback or requests on the code, documentation, or anything else, please create a GitHub
+issue. We have created some issue templates to guide you through the information needed for different types of suggestions, and opens the discussions for collaboration.
 
 Changes & Development
 ---------------------
 
-Prior to making any changes, please consider creating an issue to discuss your proposed changes
-and get feedback from people on anything to consider during implementation.
+Prior to making any changes, please consider creating an issue to discuss your proposed changes. 
+This helps us to support you with the changes and provide wider context and considerations for your implementation.
 
 Any changes to the code or documentation should be worked on in a separate fork (or branch if
 you're an organisation member) of the repository. For significant pieces of new functionality

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,64 @@
+===============
+Ways Of Working
+===============
+
+.. role:: python(code)
+   :language: python
+
+.. _`Google Python Style Guide`: https://google.github.io/styleguide/pyguide.html
+.. _`pydocstyle`: http://www.pydocstyle.org/en/stable/index.html
+.. _`black`: https://github.com/psf/black
+.. _`pylint`: https://github.com/PyCQA/pylint
+.. _`mypy`: https://github.com/python/mypy
+.. _`pyproject.toml`: pyproject.toml
+.. _`todo comments`: https://google.github.io/styleguide/pyguide.html#312-todo-comments
+.. _`old-style`: https://docs.python.org/3/library/stdtypes.html#old-string-formatting
+.. _`new-style`: https://docs.python.org/3/library/stdtypes.html#str.format
+.. _`CAF coding standards`: https://transport-for-the-north.github.io/CAF-Handbook/contribution/coding_standards/overview.html
+.. _`pytest`: https://docs.pytest.org/en/stable/
+
+Transport for the North (TfN) encourages a collaborative way of working and as such is happy
+to accept contributions on various aspects of our repositories, including:
+
+- Code maintenance and development
+- Feature requests and bug reporting
+- Documentation feedback and suggestions
+- Code examples and use cases
+
+Feedback & Requests
+-------------------
+
+For any feedback, or requests, on the code, documentation or anything else, please create a GitHub
+issue on the repository to describe you suggestion and open the discussion. We have created some
+issue templates to outline the different types of suggestions we expect.
+
+Changes & Development
+---------------------
+
+Prior to any changes consider creating an issue to discuss your proposed changes and get some
+feedback from people on anything to consider during implementation.
+
+Any changes to the code or documentation should be worked on in a separate fork (or branch if
+you're an organisation member) of the repository. For significant pieces of new functionality
+a draft pull request should be opened during development of the code. This creates a central point
+to communicate about the code being written and to keep a record of any potential issues. Once
+development is complete and the code ready for review, the draft pull request can be promoted to
+a normal pull request.
+
+For smaller pieces of work, such as a bug fix, a normal pull request can be made straight away.
+
+Coding Style
+^^^^^^^^^^^^
+
+TFN's coding follows the `CAF coding standards`_, before contributing
+to this repository we would recommend reading through the standards.
+However, at a high level the coding standards can be summarised as:
+
+- Code uses numpy-style doc-strings, checked with `pydocstyle`_
+- Code must be formatted with `black`_
+- Code must be checked, and all errors corrected, by running `pylint`_
+- Code must be checked, and all errors corrected, by running `mypy`_
+- Code must include unittests, and integration tests (where relevant), built with `pytest`_
+
+See this project's `pyproject.toml`_ to see how these tools have been set up in order
+to meet TFN's coding standards.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,18 +2,11 @@
 Ways Of Working
 ===============
 
-.. role:: python(code)
-   :language: python
-
-.. _`Google Python Style Guide`: https://google.github.io/styleguide/pyguide.html
 .. _`pydocstyle`: http://www.pydocstyle.org/en/stable/index.html
 .. _`black`: https://github.com/psf/black
 .. _`pylint`: https://github.com/PyCQA/pylint
 .. _`mypy`: https://github.com/python/mypy
 .. _`pyproject.toml`: pyproject.toml
-.. _`todo comments`: https://google.github.io/styleguide/pyguide.html#312-todo-comments
-.. _`old-style`: https://docs.python.org/3/library/stdtypes.html#old-string-formatting
-.. _`new-style`: https://docs.python.org/3/library/stdtypes.html#str.format
 .. _`CAF coding standards`: https://transport-for-the-north.github.io/CAF-Handbook/contribution/coding_standards/overview.html
 .. _`pytest`: https://docs.pytest.org/en/stable/
 
@@ -29,14 +22,14 @@ Feedback & Requests
 -------------------
 
 For any feedback, or requests, on the code, documentation or anything else, please create a GitHub
-issue on the repository to describe you suggestion and open the discussion. We have created some
-issue templates to outline the different types of suggestions we expect.
+issue to describe your suggestion and open the discussion. We have created some issue templates to
+show the information we expect for different types of suggestions.
 
 Changes & Development
 ---------------------
 
-Prior to any changes consider creating an issue to discuss your proposed changes and get some
-feedback from people on anything to consider during implementation.
+Prior to making any changes, please consider creating an issue to discuss your proposed changes
+and get feedback from people on anything to consider during implementation.
 
 Any changes to the code or documentation should be worked on in a separate fork (or branch if
 you're an organisation member) of the repository. For significant pieces of new functionality
@@ -50,9 +43,9 @@ For smaller pieces of work, such as a bug fix, a normal pull request can be made
 Coding Style
 ^^^^^^^^^^^^
 
-TFN's coding follows the `CAF coding standards`_, before contributing
-to this repository we would recommend reading through the standards.
-However, at a high level the coding standards can be summarised as:
+TFN's coding follows the `CAF coding standards`_, before contributing to this repository we would
+recommend reading through the standards. However, at a high level the coding standards can be
+summarised as:
 
 - Code uses numpy-style doc-strings, checked with `pydocstyle`_
 - Code must be formatted with `black`_


### PR DESCRIPTION
# Changes

Added CONTRIBUTING.rst to outline contribution guidelines, this only contains a brief overview of the guidance and links to CAF coding standards on CAF handbook for more detail.

I have not included the details on TODO comments because I thought we had moved away from this functionality as we no longer create issues from them.

I have also not included the multiline for loops or string formatting details because I think they should be in the CAF coding standards so we can keep this guide nice and simple.

- Closes #3 
