### PR TITLE
Removed default project from issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,11 +7,11 @@ body:
   - type: markdown
     attributes:
       value: >
-        Thank you for taking the time to fill this bug report. 
+        Thank you for taking the time to fill out this bug report. 
 
-        Please provide as much detail explaining the problem and expected result.
-        The questions below show the information we need to be able to properly
-        reproduce and fix the bug.
+        Help us help you! Please explain the problem and your expected result.
+        The questions below show the information we need to properly
+        reproduce and fix the bug, solving your problem quicker.
 
   - type: checkboxes
     id: checks

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,7 +2,6 @@ name: Bug Report
 description: File a bug report.
 title: "[Bug]: "
 labels: ["bug"]
-projects: ["Transport-for-the-North/48"]
 
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -4,10 +4,20 @@ title: "[Bug]: "
 labels: ["bug"]
 
 body:
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking the time to fill this bug report. 
+
+        Please provide as much detail explaining the problem and expected result.
+        The questions below show the information we need to be able to properly
+        reproduce and fix the bug.
+
   - type: checkboxes
     id: checks
     attributes:
       label: Version Checks
+      description: Please confirm you have checked the following.
       options:
         - label: >
             I have checked that this issue has not already been reported.
@@ -24,8 +34,9 @@ body:
     attributes:
       label: Reproducible Code Example
       description: >
-        Please follow [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports)
-        on how to provide a minimal, copy-pastable example.
+        Please provide a simple example of code which can reproduce the bug.
+        [This guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports)
+        explains how to provide a minimal, copy-pastable example.
       render: python
 
   - type: textarea
@@ -49,6 +60,8 @@ body:
       label: Issue Description
       description: >
         Please provide a description of the issue shown in the reproducible example.
+      placeholder: >
+        X does not produce the desired result when I...
     validations:
       required: true
 
@@ -58,6 +71,8 @@ body:
       label: Expected Behavior
       description: >
         Please describe or show a code example of the expected behavior.
+      placeholder: >
+        I would have expected the following to happen...
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -9,8 +9,8 @@ body:
       value: >
         Thank you for taking time to suggest this documentation improvement.
 
-        Please provide information to explain what is unclear, or missing from,
-        the documentation and an explanation of your suggestion for improvement. 
+        Please explain what is unclear or missing from the documentation and,
+        if possible, how to improve. 
 
   - type: checkboxes
     attributes:
@@ -37,7 +37,7 @@ body:
     attributes:
       label: Documentation problem
       description: >
-        Please provide a description of what documentation you believe needs to be
+        Please describe which part of the documentation needs to be
         added, fixed or improved.
       placeholder: >
         The explanation of X is missing / not clear... / doesn't explain...

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -2,7 +2,6 @@ name: Documentation Improvement
 description: Report wrong or missing documentation
 title: "[Docs]: "
 labels: [documentation]
-projects: ["Transport-for-the-North/48"]
 
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -4,6 +4,14 @@ title: "[Docs]: "
 labels: [documentation]
 
 body:
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking time to suggest this documentation improvement.
+
+        Please provide information to explain what is unclear, or missing from,
+        the documentation and an explanation of your suggestion for improvement. 
+
   - type: checkboxes
     attributes:
       label: Version checks
@@ -29,7 +37,10 @@ body:
     attributes:
       label: Documentation problem
       description: >
-        Please provide a description of what documentation you believe needs to be fixed/improved
+        Please provide a description of what documentation you believe needs to be
+        added, fixed or improved.
+      placeholder: >
+        The explanation of X is missing / not clear... / doesn't explain...
     validations:
       required: true
 
@@ -38,6 +49,10 @@ body:
     attributes:
       label: Suggested fix for documentation
       description: >
-        Please explain the suggested fix and **why** it's better than the existing documentation
+        Please explain the suggested fix and **why** it's better than the existing documentation.
+      placeholder: >
+        The documentation of X should include... / be rewritten to... / be removed
+
+        Because ...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,16 +7,14 @@ body:
   - type: markdown
     attributes:
       value: >
-        Thank you for taking time to suggest this feature, or improvement.
+        Thank you for taking time to suggest this feature or improvement.
 
-        Please provide information about the problem this feature is trying
-        to improve before explaining the details of the feature itself. If
-        there is a current workaround please include any information about this
-        and why the new feature would be better.
+        Please describe the problem this feature will improve before explaining the 
+        details of the feature itself. If there is a current workaround please include 
+        any information about this and why the new feature would be better.
 
-        For any additional information about the feature such as inputs, outputs
-        or an example implementation, please provide that for the
-        "Additional Context" question.
+        Please use the "Additional Context" question to note if this feature
+        requires specific inputs, outputs, or you have an example implementation.
 
   - type: checkboxes
     id: checks

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -4,6 +4,20 @@ title: "[Feat]: "
 labels: [enhancement]
 
 body:
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking time to suggest this feature, or improvement.
+
+        Please provide information about the problem this feature is trying
+        to improve before explaining the details of the feature itself. If
+        there is a current workaround please include any information about this
+        and why the new feature would be better.
+
+        For any additional information about the feature such as inputs, outputs
+        or an example implementation, please provide that for the
+        "Additional Context" question.
+
   - type: checkboxes
     id: checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -48,7 +48,7 @@ body:
         Please describe any alternative solution (existing functionality, 3rd party package, etc.)
         that would satisfy the feature request.
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: context

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -2,7 +2,6 @@ name: Feature Request
 description: Suggest an new feature / change to the functionality.
 title: "[Feat]: "
 labels: [enhancement]
-projects: ["Transport-for-the-North/48"]
 
 body:
   - type: checkboxes


### PR DESCRIPTION
# Changes

We don't want all issues across all repositories to be sent to the CAF project.

- Closes #11 


# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases) - NA
- [x] Has documentation (including user guide) been updated - NA
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - NA
- [x] Code linting, tests and other workflows pass - NA
