### PR TITLE
Feat: organisation dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:
+      interval: "cron
       cronjob: "0 0 28 * *"
     allow:
       # Only allow major version updates to reduce noise from minor/patch updates
@@ -24,6 +25,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     schedule:
+      interval: "cron
       cronjob: "0 0 28 * *"
     target-branch: "dev"
     allow:
@@ -38,5 +40,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
+      interval: "cron
       cronjob: "0 0 28 * *"
     open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      cronjob: "0 0 28 * *"
+    allow:
+      # Only allow major version updates to reduce noise from minor/patch updates
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+      # Allow minor versions for caf packages to ensure new versions are tested more often
+      - dependency-name: "caf.*"
+        update-types:
+          - "version-update:semver-minor"
+    # If you only want security update PRs, set this to 0
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    schedule:
+      cronjob: "0 0 28 * *"
+    target-branch: "dev"
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      cronjob: "0 0 28 * *"
+    open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "cron
+      interval: "cron"
       cronjob: "0 0 28 * *"
     allow:
       # Only allow major version updates to reduce noise from minor/patch updates
@@ -25,7 +25,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "cron
+      interval: "cron"
       cronjob: "0 0 28 * *"
     target-branch: "dev"
     allow:
@@ -40,6 +40,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "cron
+      interval: "cron"
       cronjob: "0 0 28 * *"
     open-pull-requests-limit: 1


### PR DESCRIPTION
# Changes

Org. level dependabot config which schedules pip, npm and github-actions version checks once a month on 28th.

> [!WARNING]
> I'm not sure how to test this other than merging with main and waiting until 28th

This config is also ignored in any repos which define it themselves so we might want to remove the config from individual repos if we can get it working here.

