### PR TITLE
Docs: more detailed GitHub and Python standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,20 +8,24 @@ to accept contributions on various aspects of our repositories, including:
 - Documentation feedback and suggestions
 - Code examples and use cases
 
-## Feedback & Requests
-
-If you have any feedback or requests on the code, documentation, or anything else, please create a GitHub
-issue. We have created some issue templates to guide you through the information needed for different types of suggestions, and opens the discussions for collaboration.
-
 ## Version Control
 
 CAF codebases are all hosted on [GitHub](https://github.com/Transport-for-the-North)
-and use [Git](https://git-scm.com/) for version control, see CAF Handbook's
-[GitHub section](https://transport-for-the-north.github.io/CAF-Handbook/contribution/github_wow/overview.html)
+and use [Git](https://git-scm.com/) for version control, see our [GitHub standards](standards/github.md)
 for guidance.
 
 > [!NOTE]
 > Code [releases](#releases) are managed using Semantic Versioning.
+
+## Feedback & Requests
+
+If you have any feedback or requests on the code, documentation, or anything else, please create a GitHub
+issue. We have created some issue templates to guide you through the information needed for different
+types of suggestions, and opens the discussions for collaboration.
+
+> [!NOTE]
+> See [Issues Standards](standards/github.md#issues) for TfN's full guidance on creating
+> issues.
 
 ## Changes & Development
 
@@ -37,20 +41,34 @@ a normal pull request.
 
 For smaller pieces of work, such as a bug fix, a normal pull request can be made straight away.
 
-### Coding Style
+> [!NOTE]
+> See [PR Standards](standards/github.md#pull-requests) for TfN's full guidance on creating
+> pull requests and issues.
 
-TFN's coding follows the [CAF coding standards](https://transport-for-the-north.github.io/CAF-Handbook/contribution/coding_standards/overview.html),
-before contributing to this repository we would
-recommend reading through the standards. However, at a high level the coding standards can be
-summarised as:
+### Coding Standards
+
+Python is the most commonly used programming language used with TfN, it is also the preferred
+language for most new tools. The main alternative is JavaScript / TypeScript which is used
+within the Visualisation Framework.
+
+#### Python
+
+TFN's Python coding follows the [CAF Python standards](standards/python.md), before contributing to
+this repository we would recommend reading through the standards. However, at a high level the coding
+standards can be summarised as:
 
 - Code must be formatted with [ruff format](https://docs.astral.sh/ruff/formatter/)
 - Code must be checked, and all errors corrected, by running [ruff check](https://docs.astral.sh/ruff/linter/)
 - Type annotations must be used and checked, and all errors corrected, by running [mypy](https://github.com/python/mypy)
 - Code must include unittests, and integration tests (where relevant), built with [pytest](https://docs.pytest.org/en/stable/)
 
-See the CAF template's [pyproject.toml](https://github.com/Transport-for-the-North/cookiecutter-caf/blob/main/%7B%7B%20cookiecutter.project_slug%20%7D%7D/pyproject.toml)
-to see how these tools have been set up in order to meet TfN's coding standards.
+For any new Python package repositories consider using the
+[cookiecutter-caf](https://github.com/Transport-for-the-North/cookiecutter-caf) template, which
+will create a repository structure matching the TfN standards.
+
+> [!TIP]
+> See the CAF template's [pyproject.toml](https://github.com/Transport-for-the-North/cookiecutter-caf/blob/main/%7B%7B%20cookiecutter.project_slug%20%7D%7D/pyproject.toml)
+> to see how these tools have been set up in order to meet TfN's coding standards.
 
 ## Releases
 

--- a/standards/github.md
+++ b/standards/github.md
@@ -1,0 +1,20 @@
+# GitHub Standards
+
+Outlined here are the standards / conventions used within TfN, and CAF, for using
+[Git](https://git-scm.com/) and [GitHub](https://github.com/Transport-for-the-North).
+
+> [!NOTE]
+> See [Contributing Guide](../CONTRIBUTING.md) for TfN's full contribution guidance.
+
+- [Issues](#issues)
+- [Pull Requests](#pull-requests)
+- [Commits](#commits)
+- [Branches](#branches)
+
+## Issues
+
+## Pull Requests
+
+## Commits
+
+## Branches

--- a/standards/python.md
+++ b/standards/python.md
@@ -1,0 +1,32 @@
+# Python Standards
+
+Outlined here are the standards / conventions used within TfN, and CAF, for writing Python
+code. These standards should be adhered to in all new code...
+
+> [!NOTE]
+> See [Contributing Guide](../CONTRIBUTING.md) for TfN's full contribution guidance.
+
+- [Dependency Management](#dependency-management)
+  - [requirements.txt](#requirementstxt)
+- [Linting Tools](#linting-tools)
+  - [Ruff](#ruff)
+  - [MyPy](#mypy)
+- [Testing (pytest)](#testing-pytest)
+- [Documentation](#documentation)
+  - [Docstrings](#docstrings)
+
+## Dependency Management
+
+### requirements.txt
+
+## Linting Tools
+
+### Ruff
+
+### MyPy
+
+## Testing (pytest)
+
+## Documentation
+
+### Docstrings


### PR DESCRIPTION
# Changes

> [!WARNING]
> Updated standards are work-in-progress

Added some more detail to contributing guide with links to files for more detailed GitHub and Python standards. New files currently placeholders for more detailed guides.